### PR TITLE
HEP-971: Playblast version without preprocessor reset & tooltips

### DIFF
--- a/python/tk_syntheyes/inbuilt_apps/playblast.py
+++ b/python/tk_syntheyes/inbuilt_apps/playblast.py
@@ -18,22 +18,39 @@ class PlayblastInbuiltApp(InbuiltApp):
 
     @property
     def display_name(self):
-        return "Playblast"
+        return "Playblast (Fl. Persp.)"
     
     @property
     def description(self):
-        return ""
+        return """
+        Manages rendering playblasts via SynthEyes' view 'Floating Perspective'.
+        Before starting any playblast, configure the view's display settings as these will affect the output.
+        """
         
     @property
     def commands(self):
         return {
-            "Playblast (Fl. Persp.)":
+            "Playblast":
             {
                 "callback": self.playblast,
                 "properties": {
                     "app": self,
-                    "description": "Render a playblast via the 'Render Preview'-function"
-                                   "in the SynthEyes' view 'Floating Perspective'.",
+                    "description": "Render a playblast via the 'Render Preview'-function "
+                                   "in the SynthEyes' view 'Floating Perspective'.\n"
+                                   "During the rendering process, the display-specific settings of the "
+                                   "image preprocessor are reset to ensure that colors are not altered.\n"
+                                   "Warning: This will cause SynthEyes to clear the image cache.",
+                    "environment": ["asset_step", "element_step", "shot_step"]
+                }
+            },
+            "Playblast (No Reset)":
+            {
+                "callback": self.playblast_no_reset,
+                "properties": {
+                    "app": self,
+                    "description": "Render a playblast via the 'Render Preview'-function "
+                                   "in the SynthEyes' view 'Floating Perspective' without "
+                                   "affecting the image preprocessor.",
                     "environment": ["asset_step", "element_step", "shot_step"]
                 }
             },
@@ -43,6 +60,12 @@ class PlayblastInbuiltApp(InbuiltApp):
         super().__init__(engine)
 
     def playblast(self):
+        self._playblast(True)
+
+    def playblast_no_reset(self):
+        self._playblast(False)
+
+    def _playblast(self, reset_prepset):
         hlev = self.engine.get_syntheyes_connection()
         ui = self.engine.ui
 
@@ -78,8 +101,7 @@ class PlayblastInbuiltApp(InbuiltApp):
                 return
 
         timer = Timer(0.033, 5)
-        first_undo_block = "Prepare SGTK Playblast"
-        reached_first_undo = False
+        first_undo_block = None
         try:
             active_cam = hlev.Active().cam
             shot = active_cam.shot
@@ -106,35 +128,38 @@ class PlayblastInbuiltApp(InbuiltApp):
             else:
                 os.makedirs(dir)
 
-            prepset_name = "sgtk_render_playblast"
-            prepset_path = os.path.abspath(os.path.join(self.engine.disk_location, "prepsets", prepset_name + ".prp"))
-            hlev.BeginShotChanges(shot)
-            try:
-                # 1. disable resampling in preprocessor
-                live.stabilizeMode = float(int(live.stabilizeMode) & ~128)
-                live.Call("MakeStabilizeReference")
-                        
-                # 2. load custom prepset
-                shot.Call("LoadPrepSetsFromFile", 1, prepset_path)
-            except Exception as e: raise e
-            finally: 
-                hlev.AcceptShotChanges(shot, first_undo_block)
-                reached_first_undo = True
+            if reset_prepset:
+                prepset_name = "sgtk_render_playblast"
+                prepset_path = os.path.abspath(os.path.join(self.engine.disk_location, "prepsets", prepset_name + ".prp"))
+                hlev.BeginShotChanges(shot)
+                try:
+                    # 1. disable resampling in preprocessor
+                    live.stabilizeMode = float(int(live.stabilizeMode) & ~128)
+                    live.Call("MakeStabilizeReference")
+                            
+                    # 2. load custom prepset
+                    shot.Call("LoadPrepSetsFromFile", 1, prepset_path)
+                except Exception as e: raise e
+                finally:
+                    undo_block_name = "Prepare SGTK Playblast"
+                    if not first_undo_block:
+                        first_undo_block = undo_block_name
+                    hlev.AcceptShotChanges(shot, undo_block_name)
 
-            # 3. open preprocessor to set the active prepset; 
-            # This is a workaround due to the bad type error when directly accessing prepsets from code.
-            # If this issue can be resolved, the code here can be improved, but for now this works fine.
-            hlev.PerformActionByIDAndContinue(40147) # Shot > Image Preprocessor
+                # 3. open preprocessor to set the active prepset; 
+                # This is a workaround due to the bad type error when directly accessing prepsets from code.
+                # If this issue can be resolved, the code here can be improved, but for now this works fine.
+                hlev.PerformActionByIDAndContinue(40147) # Shot > Image Preprocessor
 
-            # wait for preprocessor to open
-            timer.reset()
-            while hlev.Popup().Name() != "Image Preprocessor": # Image Preprocessor
-                timer.sleep("Error: Timeout while waiting for Image Preprocessor to open.")
+                # wait for preprocessor to open
+                timer.reset()
+                while hlev.Popup().Name() != "Image Preprocessor": # Image Preprocessor
+                    timer.sleep("Error: Timeout while waiting for Image Preprocessor to open.")
 
-            img_proc = hlev.Popup()
-            img_proc.ByID(1400).SetOption(prepset_name) # prepset dropdown; will be reverted via the undo later
+                img_proc = hlev.Popup()
+                img_proc.ByID(1400).SetOption(prepset_name) # prepset dropdown; will be reverted via the undo later
 
-            img_proc.ByID(1).ClickAndWait() # OK
+                img_proc.ByID(1).ClickAndWait() # OK
 
             # 4. hide all other cameras and clear the selection to prevent them from showing up in the playblast
             hlev.Begin()
@@ -144,7 +169,11 @@ class PlayblastInbuiltApp(InbuiltApp):
                         cam.show = False
                 hlev.ClearSelection()
             except Exception as e: raise e
-            finally: hlev.Accept("Hide other Cameras")
+            finally:
+                undo_block_name = "Hide Other Cameras"
+                if not first_undo_block:
+                    first_undo_block = undo_block_name
+                hlev.Accept(undo_block_name)
 
             # 5. open floating perspective if not already present            
             window_title = "Perspective Window"
@@ -226,7 +255,7 @@ class PlayblastInbuiltApp(InbuiltApp):
             )
             return
         finally: 
-            if reached_first_undo:
+            if first_undo_block:
                 self._undo_playblast_changes(first_undo_block)
 
         ui.message_box(

--- a/python/tk_syntheyes/ui/base_panel.py
+++ b/python/tk_syntheyes/ui/base_panel.py
@@ -34,8 +34,10 @@ class BasePanel(QWidget, Ui_BasePanel):
         #if self.gridLayout.rowCount() - 1 > row:
         self.update_spacers()
 
-    def insert_button(self, icon:QIcon=None, text="", row=-1, callback=None):
+    def insert_button(self, icon:QIcon=None, text="", tooltip=None, row=-1, callback=None):
         btn = QPushButton(icon, text, self)
+        if tooltip:
+            btn.setToolTip(tooltip)
         btn.setText(text)
         if callback:
             btn.clicked.connect(callback)
@@ -47,7 +49,7 @@ class BasePanel(QWidget, Ui_BasePanel):
             self.update_preferred_width()
         return btn
     
-    def insert_menu_button(self, panel, icon:QIcon=None, row=-1, is_back_button=False):
+    def insert_menu_button(self, panel, icon:QIcon=None, tooltip=None, row=-1, is_back_button=False):
         if is_back_button and self._btn_back:
             return self._btn_back
         
@@ -56,7 +58,7 @@ class BasePanel(QWidget, Ui_BasePanel):
 
         right = self.panel_depth <= panel.panel_depth        
         self.insert_menu_indicator(right, row)
-        btn = self.insert_button(icon, "Back" if is_back_button else panel.name, row)
+        btn = self.insert_button(icon, "Back" if is_back_button else panel.name, tooltip, row)
         
         if is_back_button:
             self._btn_back = btn

--- a/python/tk_syntheyes/ui/main_window.py
+++ b/python/tk_syntheyes/ui/main_window.py
@@ -340,13 +340,15 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 # already have sub menu
                 panel = sub_panel
             else:
+                # get command description
+                description = command.properties.get("description")
                 # create new sub menu
                 sub_panel: BasePanel = self._init_panel(BasePanel, item_label, panel, False, False, False) #TODO Consider whether the sub panels should be added to the quick select or not
-                self._link_panel(panel.insert_menu_button(sub_panel), sub_panel)
+                self._link_panel(panel.insert_menu_button(sub_panel, tooltip=description), sub_panel)
                 panel = sub_panel
 
         # Finally create the command button
-        return panel.insert_button(None, parts[-1], -1, command.callback)
+        return panel.insert_button(None, parts[-1], command.properties["description"], -1, command.callback)
     
 
     def _link_panel(self, button, panel_to):


### PR DESCRIPTION
Ticket:
- https://lavalmi.atlassian.net/jira/servicedesk/projects/HEP/queues/custom/2/HEP-971

Features:
- Alternate playblast version to bypass cache clearing by not changing image preprocessor
- Tooltips for buttons based on app command descriptions

Dev Config:
- Engines:
  - tk-syntheyes

Environment:
- Project: matchmove_dev
- Test scene: Shots → Sequence 010 → Shot 010_010 → Step MM → Task mm → SimpleTestScene.v049.sni
- SynthEyes Pro 2024 Build 1057 64-bit installed at "C:\Program Files\BorisFX\SynthEyes 2024\SynthEyes64.exe"
- Shotgun python version: 3.10.13

Testing Focus:
- Test both Playblast versions
  - Playblast: Renders playblast after temporarily resetting the colors of the image preprocessor → output with normal colors
  - Playblast (No Reset): Renders playblast without affecting image preprocessor → output affected by image preprocessor changes 
- Verify tooltips are working correctly
  - Hover over any non-menu command button while the SG panel is the active window