### PR TITLE
HEP-1124: SynthEyes: 'Save Changes'-Dialog on New File

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -585,3 +585,39 @@ class SynthEyesEngine(Engine):
                 return True
         
         return False
+
+    def prompt_to_save_changes(self):
+        """
+        Opens a Qt dialog to allow the user to save unsaved changes if present.
+
+        :returns: False if the action was Canceled, True otherwise
+        """
+        from sgtk.platform.qt import QtCore, QtGui
+
+        hlev = self.get_syntheyes_connection()
+        
+        if hlev.HasChanged():
+            yes = QtGui.QMessageBox.Yes
+            no = QtGui.QMessageBox.No
+            cancel = QtGui.QMessageBox.Cancel
+            try:
+                QtGui.QApplication.setOverrideCursor(QtCore.Qt.ArrowCursor)
+                res = self.ui.message_box(
+                    QtGui.QMessageBox.Information,
+                    "Unsaved Changes",
+                    "The current scene has unsaved changes. Do you want to save before closing?",
+                    yes | no | cancel
+                )
+            except:
+                raise
+            finally:
+                QtGui.QApplication.restoreOverrideCursor()
+            
+            if res == yes:
+                self.save_session()
+            elif res == no:
+                pass
+            else:
+                return False
+        
+        return True

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-syntheyes.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-syntheyes.py
@@ -91,9 +91,9 @@ class SceneOperation(HookClass):
 
         elif operation == "reset":
             # Ask the user to close popups. Otherwise SynthEyes might crash.
-            if engine.check_for_popups():
+            if engine.check_for_popups() or not engine.prompt_to_save_changes():
                 return False
-            
+
             hlev.ClearChanged()
             hlev.PerformActionByIDAndContinue(40610) # File > Close
             return True


### PR DESCRIPTION
Ticket:
- https://lavalmi.atlassian.net/jira/servicedesk/projects/HEP/queues/custom/2/HEP-1124

Features:
- Added 'Save changes'-dialog on New File-action: Asks the user if changes should be saved before closing

Dependecies:
- None

Dev:
- tk-syntheyes

Environment:
- Project: VG (any should work)
- Shots → **Sequence** VG_E100_999 → **Shot** VG_E100_999_010 → **Step** MM → **Task** mm → pipeTest [v002]
- SynthEyes 2024
- Shotgun python version: 3.10.13

Test Scenario:
1. Modify & New File
  • Make changes to the opened file by placing trackers or similar, e.g.:  
![grafik](https://github.com/user-attachments/assets/063c9ef9-3a43-408b-abaf-fa2d69ce7f1d)
  • _File Open..._ → _+ New File_
  • Verify that an _Unsaved Changes_-dialog pops up.
  • Verify that all options work indeed as intended (Yes | No | Cancel).