### PR TITLE
Show python console & Improved Startup Crash Handling

### DIFF
--- a/python/tk_syntheyes/ui/main_window.py
+++ b/python/tk_syntheyes/ui/main_window.py
@@ -1,6 +1,3 @@
-import importlib
-import importlib.util
-import inspect
 import os
 import sys
 import time
@@ -10,9 +7,9 @@ from engine import SynthEyesEngine
 from PySide2.QtCore import (Property, QEasingCurve, QEvent, QPropertyAnimation,
                             QSize, Qt, Signal, Slot)
 from PySide2.QtGui import QCursor, QGuiApplication, QKeySequence
-from PySide2.QtWidgets import (QApplication, QBoxLayout, QLayout, QLayoutItem,
-                               QMainWindow, QMenuBar, QMessageBox, QPushButton,
-                               QVBoxLayout, QWidget)
+from PySide2.QtWidgets import (QApplication, QBoxLayout, QLayout,
+                               QLayoutItem, QMainWindow, QMenuBar, QMessageBox,
+                               QPushButton, QVBoxLayout, QWidget)
 from tk_syntheyes import logging_console
 from tk_syntheyes.app_command import AppCommand
 from tk_syntheyes.inbuilt_app import InbuiltApp
@@ -43,6 +40,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.click_pos = None
         self._menu_click_time = time.time()
         
+        self._show_python = self.actionShow_Python.isChecked
+        self.actionShow_Python.triggered.connect(self.info_on_toggle_show_python)
         self._auto_resize = self.actionAuto_Resize.isChecked
         self._stays_on_top = self.actionStays_On_Top.isChecked
         self._borderless = self.actionBorderless.isChecked
@@ -65,7 +64,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.generate_panels()
 
         # Initialize quick select
-        self.btn_quick_select.clicked.connect(lambda: self._switch_quick_select())
+        self.btn_quick_select.clicked.connect(self._switch_quick_select)
 
         ### Setup animations ###
         self._anim_panel_transition = QPropertyAnimation(self, b"panel_split_factor", self)
@@ -665,6 +664,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if not os.path.exists(config_dir):
             os.makedirs(config_dir)
 
+        if not self._config.has_section("Python"):
+            self._config.add_section("Python")
+        self._config.set("Python", "show", str(self._show_python()))
+
         ### Save UI state to config ###
         if not self._config.has_section("UI"):
             self._config.add_section("UI")
@@ -704,6 +707,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.resize(int(size[0]), int(size[1]))
         except:
             pass
+        # show python; Only for menu, this setting has to be read way earlier
+        self.actionShow_Python.setChecked(self._config.getboolean("Python", "show", fallback=self._show_python()))
         # auto_resize
         self.actionAuto_Resize.setChecked(self._config.getboolean("UI", "auto_resize", fallback=self._auto_resize()))
         # stays_on_top
@@ -717,3 +722,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         ######################
         
         return success
+    
+
+    def info_on_toggle_show_python(self):
+        self.message_box(QMessageBox.Icon.Information, "Requires restart", "Restarting SynthEyes via ShotGrid is required in order for this setting to take effect.")

--- a/python/tk_syntheyes/ui/ui_main_window.py
+++ b/python/tk_syntheyes/ui/ui_main_window.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ################################################################################
-## Form generated from reading UI file 'mainmFzMAR.ui'
+## Form generated from reading UI file 'mainUMzFQr.ui'
 ##
 ## Created by: Qt User Interface Compiler version 5.15.2
 ##
@@ -48,6 +48,9 @@ class Ui_MainWindow(object):
         self.actionRecenter_Window.setObjectName(u"actionRecenter_Window")
         self.actionMove_to_Cursor = QAction(MainWindow)
         self.actionMove_to_Cursor.setObjectName(u"actionMove_to_Cursor")
+        self.actionShow_Python = QAction(MainWindow)
+        self.actionShow_Python.setObjectName(u"actionShow_Python")
+        self.actionShow_Python.setCheckable(True)
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
         self.vertical_layout = QVBoxLayout(self.centralwidget)
@@ -79,7 +82,7 @@ class Ui_MainWindow(object):
         self.sca_quick_select.setWidgetResizable(True)
         self.sca_quick_select_contents = QWidget()
         self.sca_quick_select_contents.setObjectName(u"sca_quick_select_contents")
-        self.sca_quick_select_contents.setGeometry(QRect(0, 0, 206, 16))
+        self.sca_quick_select_contents.setGeometry(QRect(0, 0, 210, 16))
         sizePolicy.setHeightForWidth(self.sca_quick_select_contents.sizePolicy().hasHeightForWidth())
         self.sca_quick_select_contents.setSizePolicy(sizePolicy)
         self.verticalLayout = QVBoxLayout(self.sca_quick_select_contents)
@@ -106,7 +109,7 @@ class Ui_MainWindow(object):
         self.sca_left.setWidgetResizable(True)
         self.pnl_left = QWidget()
         self.pnl_left.setObjectName(u"pnl_left")
-        self.pnl_left.setGeometry(QRect(0, 0, 207, 341))
+        self.pnl_left.setGeometry(QRect(0, 0, 207, 339))
         self.layout_left = QVBoxLayout(self.pnl_left)
         self.layout_left.setSpacing(0)
         self.layout_left.setObjectName(u"layout_left")
@@ -123,7 +126,7 @@ class Ui_MainWindow(object):
         self.sca_right.setWidgetResizable(True)
         self.pnl_right = QWidget()
         self.pnl_right.setObjectName(u"pnl_right")
-        self.pnl_right.setGeometry(QRect(0, 0, 16, 324))
+        self.pnl_right.setGeometry(QRect(0, 0, 16, 326))
         self.layout_right = QVBoxLayout(self.pnl_right)
         self.layout_right.setSpacing(0)
         self.layout_right.setObjectName(u"layout_right")
@@ -143,7 +146,7 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QMenuBar(MainWindow)
         self.menubar.setObjectName(u"menubar")
-        self.menubar.setGeometry(QRect(0, 0, 227, 21))
+        self.menubar.setGeometry(QRect(0, 0, 227, 22))
         self.menuFile = QMenu(self.menubar)
         self.menuFile.setObjectName(u"menuFile")
         self.menuSettings = QMenu(self.menubar)
@@ -162,6 +165,8 @@ class Ui_MainWindow(object):
         self.menuFile.addAction(self.actionOpen_Console)
         self.menuFile.addSeparator()
         self.menuFile.addAction(self.actionExit_SynthEyes)
+        self.menuSettings.addAction(self.actionShow_Python)
+        self.menuSettings.addSeparator()
         self.menuSettings.addAction(self.actionAuto_Resize)
         self.menuSettings.addAction(self.actionStays_On_Top)
         self.menuSettings.addAction(self.actionBorderless)
@@ -180,6 +185,7 @@ class Ui_MainWindow(object):
         self.actionMinimize_Window.setText(QCoreApplication.translate("MainWindow", u"Minimize Window", None))
         self.actionRecenter_Window.setText(QCoreApplication.translate("MainWindow", u"Recenter Window", None))
         self.actionMove_to_Cursor.setText(QCoreApplication.translate("MainWindow", u"Move to Cursor", None))
+        self.actionShow_Python.setText(QCoreApplication.translate("MainWindow", u"Show Python", None))
         self.btn_quick_select.setText("")
         self.menuFile.setTitle(QCoreApplication.translate("MainWindow", u"File", None))
         self.menuSettings.setTitle(QCoreApplication.translate("MainWindow", u"Settings", None))

--- a/qt_ui/main.ui
+++ b/qt_ui/main.ui
@@ -85,7 +85,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>206</width>
+           <width>210</width>
            <height>16</height>
           </rect>
          </property>
@@ -168,7 +168,7 @@
              <x>0</x>
              <y>0</y>
              <width>207</width>
-             <height>341</height>
+             <height>339</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="layout_left">
@@ -211,7 +211,7 @@
              <x>0</x>
              <y>0</y>
              <width>16</width>
-             <height>324</height>
+             <height>326</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="layout_right">
@@ -246,7 +246,7 @@
      <x>0</x>
      <y>0</y>
      <width>227</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -265,6 +265,8 @@
     <property name="title">
      <string>Settings</string>
     </property>
+    <addaction name="actionShow_Python"/>
+    <addaction name="separator"/>
     <addaction name="actionAuto_Resize"/>
     <addaction name="actionStays_On_Top"/>
     <addaction name="actionBorderless"/>
@@ -329,6 +331,14 @@
   <action name="actionMove_to_Cursor">
    <property name="text">
     <string>Move to Cursor</string>
+   </property>
+  </action>
+  <action name="actionShow_Python">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Python</string>
    </property>
   </action>
  </widget>

--- a/startup.py
+++ b/startup.py
@@ -10,9 +10,11 @@
 
 import os
 import sys
+from configparser import SafeConfigParser
 
 import sgtk
 from sgtk.platform import LaunchInformation, SoftwareLauncher
+
 
 class SynthEyesLauncher(SoftwareLauncher):
     """
@@ -63,10 +65,22 @@ class SynthEyesLauncher(SoftwareLauncher):
             args = " ".join([args, "-start", startup_path])
 
         # Set the syntheyes python path to point to the shotgun python executable to ensure package compatibility. Ignore this If the path is already present to allow overwriting the default path if necessary.
-        # Use the python or pythonw executable, depending on the environment specifications. pythonw is the default.
+        # Use the python or pythonw executable, depending on the custom syntheyes config file in the user path. pythonw is the default.
         if not os.environ.get("SYNTHEYES_PYTHON_PATH"):
-            show_console = os.environ.get("SYNTHEYES_SHOW_CONSOLE")
-            show_console = show_console is not None and show_console.lower() in ("true", "yes", "y", "1", "on")
+            # Load visibility setting from sgtk SynthEyes config
+            user_path = os.path.expandvars(os.path.expanduser({
+                "darwin": "~/Library/Application Support/SynthEyes",
+                "win32": "%APPDATA%/SynthEyes",
+                "linux": "~/.SynthEyes"}[sys.platform])
+            )
+            config = SafeConfigParser()
+
+            try:
+                config.read(os.path.join(user_path, 'sgtk_tk-syntheyes.ini'))
+                show_console = config.getboolean("Python", "show")
+            except Exception:
+                show_console = False
+
             os.environ["SYNTHEYES_PYTHON_PATH"] = sys.executable if show_console else "w".join(os.path.splitext(sys.executable))
 
         # Check the engine settings to see whether any plugins have been

--- a/startup/bootstrap.py
+++ b/startup/bootstrap.py
@@ -14,6 +14,7 @@ It sets up the Toolkit context and prepares the tk-syntheyes engine.
 """
 import os
 import sys
+import traceback
 
 import sgtk
 
@@ -102,7 +103,12 @@ def start_toolkit():
 #input("...")
 
 # Fire up Toolkit and the environment engine
-start_toolkit()
-
-if g_engine:
-    sys.exit(g_engine.qt_app.exec_())
+try:
+    start_toolkit()
+except Exception as e:
+    print("".join(traceback.format_exception(e)))
+    input("ERROR: Could not start the sgtk-SynthEyes-engine.\nHit Enter to exit...")
+    raise e
+else:
+    if g_engine:
+        sys.exit(g_engine.qt_app.exec_())


### PR DESCRIPTION
Features:
- Added setting to menubar to enable python console after restart
- Removed SYNTHEYES_SHOW_CONSOLE environment variable
- Added better crash handling on startup → should prevent console from closing without any error messages

Dependecies:
- None

Dev:
- tk-syntheyes

Environment:
- Any Project
- SynthEyes 2024
- Python 3.10.13

Test Scenario:
1. Start SynthEyes → Should open normally
2. Enable _Settings > Show Python_
3. Open file _%appdata%/syntheyes/sgtk_tk-syntheyes.ini_ (Win+R > _enter path_ > Enter) → Check that there is a _[Python]_ section with _show = True_
4. Close SynthEyes and Engine and restart
5. Python Console window should open too