### PR TITLE
HEP-1196: Activate "Bigger/More Precise" for Maya ascii exporter

### DIFF
--- a/hooks/tk-multi-publish2/exports/camera/ma/mayaupd.txt
+++ b/hooks/tk-multi-publish2/exports/camera/ma/mayaupd.txt
@@ -18,4 +18,4 @@ s embedMeshes 3000
 s from_prefix 00
 s to_prefix 00
 d far_clip 10
-d enhance 0
+d enhance 1

--- a/hooks/tk-multi-publish2/exports/object_track/ma/mayaupd.txt
+++ b/hooks/tk-multi-publish2/exports/object_track/ma/mayaupd.txt
@@ -18,4 +18,4 @@ s embedMeshes 3200
 s from_prefix 00
 s to_prefix 00
 d far_clip 10
-d enhance 0
+d enhance 1


### PR DESCRIPTION
Ticket:
- https://lavalmi.atlassian.net/jira/servicedesk/projects/HEP/queues/custom/2/HEP-1196

Features:
- Enabeld option "Bigger/More Precise" for Maya Ascii Updated exporter for camera and object_track exports

Dependecies:
- None

Dev:
- tk-syntheyes

Environment:
- Any Project
- SynthEyes 2024
- Python 3.10.13

Test Scenario:
1. Publish Camera as Maya ASCII Updated
2. Open File in Maya, open Graph Editor and check translation channels → Should be a smooth curve instead of visible steps