### PR TITLE
HEP-1327: Prevent extra st maps from Nuke Export

### DIFF
--- a/hooks/tk-multi-publish2/exports/camera/nk/nuke5.txt
+++ b/hooks/tk-multi-publish2/exports/camera/nk/nuke5.txt
@@ -1,7 +1,7 @@
 s workarea 3200
 d userStart 0
 d rescale 1
-d useLensDistort 0
+d useLensDistort 1
 d allowSolverDistortion 0
 s mapext 65787200
 s writeOBJs 3000

--- a/hooks/tk-multi-publish2/exports/camera_track/nk/nuke5.txt
+++ b/hooks/tk-multi-publish2/exports/camera_track/nk/nuke5.txt
@@ -1,7 +1,7 @@
 s workarea 3200
 d userStart 0
 d rescale 1
-d useLensDistort 0
+d useLensDistort 1
 d allowSolverDistortion 0
 s mapext 65787200
 s writeOBJs 3000

--- a/hooks/tk-multi-publish2/exports/geometry/nk/nuke5.txt
+++ b/hooks/tk-multi-publish2/exports/geometry/nk/nuke5.txt
@@ -1,7 +1,7 @@
 s workarea 3200
 d userStart 0
 d rescale 1
-d useLensDistort 0
+d useLensDistort 1
 d allowSolverDistortion 0
 s mapext 65787200
 s writeOBJs 3000

--- a/hooks/tk-multi-publish2/exports/object_track/nk/nuke5.txt
+++ b/hooks/tk-multi-publish2/exports/object_track/nk/nuke5.txt
@@ -1,7 +1,7 @@
 s workarea 3200
 d userStart 0
 d rescale 1
-d useLensDistort 0
+d useLensDistort 1
 d allowSolverDistortion 0
 s mapext 65787200
 s writeOBJs 3300


### PR DESCRIPTION
Features:
- Changed Nuke export settings to prevent SynthEyes from automatically generating ST maps in the export folder
- SynthEyes will now try to solve the distortion via a Nuke node instead (should make the st maps obsolete in most cases)

Test Scenario:
- Publish any .nk variant with and without this PR
- If 2 St map exrs are exported without this PR, verify that the PR prevents these files from being created